### PR TITLE
chore: update S3 dependency module constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Available targets:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_config_bucket"></a> [config\_bucket](#module\_config\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 4.1 |
+| <a name="module_config_bucket"></a> [config\_bucket](#module\_config\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 5.13 |
 | <a name="module_tags"></a> [tags](#module\_tags) | cloudopsworks/tags/local | 1.0.9 |
 
 ## Resources

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -17,7 +17,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_config_bucket"></a> [config\_bucket](#module\_config\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 4.1 |
+| <a name="module_config_bucket"></a> [config\_bucket](#module\_config\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 5.13 |
 | <a name="module_tags"></a> [tags](#module\_tags) | cloudopsworks/tags/local | 1.0.9 |
 
 ## Resources

--- a/s3.tf
+++ b/s3.tf
@@ -109,7 +109,7 @@ data "aws_iam_policy_document" "config_bucket_policy" {
 module "config_bucket" {
   count                                 = var.is_hub ? 1 : 0
   source                                = "terraform-aws-modules/s3-bucket/aws"
-  version                               = "~> 4.1"
+  version                               = "~> 5.13"
   bucket                                = local.bucket_name
   acl                                   = "private"
   control_object_ownership              = true


### PR DESCRIPTION
## Summary

- Update terraform-aws-modules/s3-bucket/aws constraint from 4.x to 5.x latest line compatible with AWS provider 6.x
- Confirm cloudopsworks/tags/local remains current at 1.0.9
- Verify OpenTofu resolves config_bucket to 5.13.0 with AWS provider 6.45.0

+semver: patch